### PR TITLE
Translate README files to Korean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # Reactor Core
 
-[![Join the chat at https://gitter.im/reactor/reactor](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/reactor/reactor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Reactor Core](https://maven-badges.herokuapp.com/maven-central/io.projectreactor/reactor-core/badge.svg?style=plastic)](https://mvnrepository.com/artifact/io.projectreactor/reactor-core) [![Latest](https://img.shields.io/github/release/reactor/reactor-core/all.svg)]() 
+[![https://gitter.im/reactor/reactor에서 채팅에 참여하세요](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/reactor/reactor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Reactor Core](https://maven-badges.herokuapp.com/maven-central/io.projectreactor/reactor-core/badge.svg?style=plastic)](https://mvnrepository.com/artifact/io.projectreactor/reactor-core) [![Latest](https://img.shields.io/github/release/reactor/reactor-core/all.svg)]()
 
 [![CI on GHA](https://github.com/reactor/reactor-core/actions/workflows/publish.yml/badge.svg)](https://github.com/reactor/reactor-core/actions/workflows/publish.yml)
 [![CodeQL](https://github.com/reactor/reactor-core/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/reactor/reactor-core/actions/workflows/codeql-analysis.yml)
 
-Non-Blocking [Reactive Streams](https://www.reactive-streams.org/) Foundation for the JVM both implementing a [Reactive Extensions](https://reactivex.io) inspired API and efficient event streaming support.
+JVM을 위한 비차단 [Reactive Streams](https://www.reactive-streams.org/) 기반으로, [Reactive Extensions](https://reactivex.io)에서 영감을 받은 API와 효율적인 이벤트 스트리밍 지원을 모두 제공합니다.
 
-Since `3.3.x`, this repository also contains `reactor-tools`, a java agent aimed at helping with debugging of Reactor code.
+`3.3.x`부터 이 저장소에는 Reactor 코드를 디버깅하는 데 도움을 주는 자바 에이전트 `reactor-tools`도 포함되어 있습니다.
 
-## Getting it
-   
-**Reactor 3 requires Java 8 or + to run**.
+## 다운로드
 
-With Gradle from repo.spring.io or Maven Central repositories (stable releases only):
+**Reactor 3을 실행하려면 Java 8 이상이 필요합니다.**
+
+repo.spring.io 또는 Maven Central 저장소(안정 버전만 제공)에서 Gradle을 사용할 수 있습니다.
 
 ```groovy
 repositories {
     mavenCentral()
 
-    // Uncomment to get access to Snapshots
+    // 스냅샷을 사용하려면 아래 주석을 해제하세요
     // maven { url "https://repo.spring.io/snapshot" }
 }
 
@@ -28,100 +28,91 @@ dependencies {
     compile "io.projectreactor:reactor-core:3.8.0-M7"
     testCompile "io.projectreactor:reactor-test:3.8.0-M7"
 
-    // Alternatively, use the following for latest snapshot artifacts in this line
+    // 최신 스냅샷 아티팩트를 사용하려면 다음을 사용하세요
     // compile "io.projectreactor:reactor-core:3.8.0-SNAPSHOT"
     // testCompile "io.projectreactor:reactor-test:3.8.0-SNAPSHOT"
 
-    // Optionally, use `reactor-tools` to help debugging reactor code
+    // Reactor 코드 디버깅을 돕기 위해 `reactor-tools`를 선택적으로 사용할 수 있습니다
     // implementation "io.projectreactor:reactor-tools:3.8.0-M7"
 }
 ```
 
-See the [reference documentation](https://projectreactor.io/docs/core/release/reference/docs/index.html#getting)
-for more information on getting it (eg. using Maven, or on how to get milestones and snapshots).
+Maven 사용 방법, 마일스톤 및 스냅샷 버전 다운로드 방법 등 더 자세한 내용은 [레퍼런스 문서](https://projectreactor.io/docs/core/release/reference/docs/index.html#getting)를 확인하세요.
 
-> **Note about Android support**: Reactor 3 doesn't officially support nor target Android.
-However it should work fine with Android SDK 21 (Android 5.0) and above. See the
-[complete note](https://projectreactor.io/docs/core/release/reference/docs/index.html#prerequisites)
-in the reference guide.
+> **Android 지원 참고**: Reactor 3는 공식적으로 Android를 지원하거나 대상으로 삼지 않습니다.
+> 하지만 Android SDK 21(Android 5.0) 이상에서는 문제없이 동작합니다. 자세한 내용은 레퍼런스 가이드의 [전체 안내](https://projectreactor.io/docs/core/release/reference/docs/index.html#prerequisites)를 참고하세요.
 
-## Trouble building the project?
-Since the introduction of [Java Multi-Release JAR File](https://openjdk.org/jeps/238) 
-support one needs to have JDK 8, 9, and 21 available on the classpath. All the JDKs should 
-be automatically [detected](https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection) 
-or [provisioned](https://docs.gradle.org/current/userguide/toolchains.html#sec:provisioning) 
-by Gradle Toolchain. 
+## 프로젝트 빌드가 어려우신가요?
+[Java Multi-Release JAR File](https://openjdk.org/jeps/238) 지원이 도입된 이후에는 클래스패스에서 JDK 8, 9, 21을 모두 사용할 수 있어야 합니다. Gradle Toolchain이 모든 JDK를 자동으로 [감지](https://docs.gradle.org/current/userguide/toolchains.html#sec:auto_detection)하거나 [제공](https://docs.gradle.org/current/userguide/toolchains.html#sec:provisioning)합니다.
 
-However, if you see error message such as `No matching toolchains found for requested 
-specification: {languageVersion=X, vendor=any, implementation=vendor-specific}` (where 
-`X` can be 8, 9 or 21), it means that you need to install the missing JDK:
+하지만 `No matching toolchains found for requested specification: {languageVersion=X, vendor=any, implementation=vendor-specific}`(여기서 `X`는 8, 9 또는 21)와 같은 오류가 표시되면 누락된 JDK를 설치해야 합니다.
 
-### Installing JDKs with [SDKMAN!](https://sdkman.io/)
+### [SDKMAN!](https://sdkman.io/)으로 JDK 설치하기
 
-In the project root folder run [SDKMAN env initialization](https://sdkman.io/usage#env): 
+프로젝트 루트에서 [SDKMAN 환경 초기화](https://sdkman.io/usage#env)를 실행하세요.
 
 ```shell
 sdk env install
 ```
 
-then (if needed) install JDK 9: 
+필요하다면 JDK 9를 설치합니다.
 
 ```shell
 sdk install java $(sdk list java | grep -Eo -m1 '9\b\.[ea|0-9]{1,2}\.[0-9]{1,2}-open')
 ```
 
-then (if needed) install JDK 21:
+필요하다면 JDK 21도 설치합니다.
 
 ```shell
 sdk install java $(sdk list java | grep -Eo -m1 '21\b\.[ea|0-9]{1,2}\.[0-9]{1,2}-open')
 ```
 
-When the installations succeed, try to refresh the project and see that it builds.
+설치가 완료되면 프로젝트를 새로고침하고 빌드가 성공하는지 확인하세요.
 
-### Installing JDKs manually
+### JDK를 수동으로 설치하기
 
-The manual Operation-system specific JDK installation
-is well explained in the [official docs](https://docs.oracle.com/en/java/javase/20/install/overview-jdk-installation.html)
+운영체제별 수동 설치 방법은 [공식 문서](https://docs.oracle.com/en/java/javase/20/install/overview-jdk-installation.html)에 자세히 정리되어 있습니다.
 
-### Building the doc
+### 문서 빌드하기
 
-The current active shell JDK version must be compatible with JDK17 or higher for Antora to build successfully.
-So, just ensure that you have installed JDK 21, as described above and make it as the current one. 
+Antora로 문서를 빌드하려면 현재 쉘에서 사용 중인 JDK 버전이 JDK 17 이상과 호환되어야 합니다. 위에서 설명한 대로 JDK 21을 설치하고 현재 버전으로 설정하세요.
 
-Then you can build the antora documentation like this:
+그런 다음 Antora 문서는 다음과 같이 빌드할 수 있습니다.
+
 ```shell
 ./gradlew docs
 ```
 
-The documentation is generated in `docs/build/site/index.html` and in `docs/build/distributions/reactor-core-<version>-docs.zip` 
-If a PDF file should also be included in the generated docs zip file, then you need to specify `-PforcePdf` option:
+문서는 `docs/build/site/index.html`과 `docs/build/distributions/reactor-core-<version>-docs.zip`에 생성됩니다.
+
+생성된 ZIP 파일에 PDF를 포함하려면 `-PforcePdf` 옵션을 지정하세요.
 
 ```shell
 ./gradlew docs -PforcePdf
 ```
-Notice that PDF generation requires the `asciidoctor-pdf` command to be available in the PATH. 
-For example, on Mac OS, you can install such command like this:
+
+PDF 생성에는 `asciidoctor-pdf` 명령이 PATH에 존재해야 합니다. 예를 들어 macOS에서는 다음과 같이 설치할 수 있습니다.
 
 ```shell
 brew install asciidoctor
 ```
 
-## Getting Started
+## 시작하기
 
-New to Reactive Programming or bored of reading already ? Try the [Introduction to Reactor Core hands-on](https://github.com/reactor/lite-rx-api-hands-on) !
+리액티브 프로그래밍이 처음이거나 글로 읽는 것이 지루하시다면 [Reactor Core Hands-on](https://github.com/reactor/lite-rx-api-hands-on)을 직접 체험해 보세요!
 
-If you are familiar with RxJava or if you want to check more detailed introduction, be sure to check 
-https://www.infoq.com/articles/reactor-by-example !
+RxJava에 익숙하거나 더 자세한 소개를 보고 싶다면 https://www.infoq.com/articles/reactor-by-example 을 참고하세요.
 
 ## Flux
 
-A Reactive Streams Publisher with basic flow operators.
-- Static factories on Flux allow for source generation from arbitrary callbacks types.
-- Instance methods allows operational building, materialized on each subscription (_Flux#subscribe()_, ...) or multicasting operations (such as _Flux#publish_ and _Flux#publishNext_).
+기본 흐름 연산자를 갖춘 Reactive Streams Publisher입니다.
+- Flux의 정적 팩토리는 임의의 콜백 타입에서 소스를 생성할 수 있습니다.
+- 인스턴스 메서드는 각 구독 시점(_Flux#subscribe()_ 등)에 물질화되거나, _Flux#publish_, _Flux#publishNext_와 같은 멀티캐스팅 연산을 제공합니다.
 
 [<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.1.3.RELEASE/src/docs/marble/flux.png" width="500" style="background-color: white">](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Flux.html)
 
-Flux in action :
+Flux 사용 예시는 다음과 같습니다.
+
 ```java
 Flux.fromIterable(getSomeLongList())
     .mergeWith(Flux.interval(100))
@@ -134,13 +125,15 @@ Flux.fromIterable(getSomeLongList())
 ```
 
 ## Mono
-A Reactive Streams Publisher constrained to *ZERO* or *ONE* element with appropriate operators. 
-- Static factories on Mono allow for deterministic *zero or one* sequence generation from arbitrary callbacks types.
-- Instance methods allows operational building, materialized on each _Mono#subscribe()_ or _Mono#get()_ eventually called.
+
+적절한 연산자와 함께 *0개* 또는 *1개*의 요소만 내보내는 Reactive Streams Publisher입니다.
+- Mono의 정적 팩토리는 임의의 콜백 타입에서 *0 또는 1*개의 시퀀스를 결정적으로 생성합니다.
+- 인스턴스 메서드는 _Mono#subscribe()_ 또는 _Mono#get()_ 호출 시점에 물질화되는 연산을 구성할 수 있습니다.
 
 [<img src="https://raw.githubusercontent.com/reactor/reactor-core/v3.4.1/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/mono.svg" width="500" style="background-color: white">](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html)
 
-Mono in action :
+Mono 사용 예시는 다음과 같습니다.
+
 ```java
 Mono.fromCallable(System::currentTimeMillis)
     .flatMap(time -> Mono.first(serviceA.findRecent(time), serviceB.findRecent(time)))
@@ -149,7 +142,8 @@ Mono.fromCallable(System::currentTimeMillis)
     .subscribe(System.out::println);
 ```
 
-Blocking Mono result :
+Mono를 블로킹 방식으로 사용하는 방법은 다음과 같습니다.
+
 ```java
 Tuple2<Instant, Instant> nowAndLater = Mono.zip(
     Mono.just(Instant.now()),
@@ -159,17 +153,14 @@ Tuple2<Instant, Instant> nowAndLater = Mono.zip(
 
 ## Schedulers
 
-Reactor uses a [Scheduler](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html) as a
-contract for arbitrary task execution. It provides some guarantees required by Reactive
-Streams flows like FIFO execution.
+Reactor는 [Scheduler](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Scheduler.html)를 임의 작업 실행을 위한 계약으로 사용합니다. Scheduler는 FIFO 실행과 같은 Reactive Streams 흐름에 필요한 보장을 제공합니다.
 
-You can use or create efficient [schedulers](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html)
-to jump thread on the producing flows (subscribeOn) or receiving flows (publishOn):
+프로듀싱 흐름(subscribeOn)이나 소비 흐름(publishOn)에서 쓰레드를 전환하려면 효율적인 [스케줄러](https://projectreactor.io/docs/core/release/api/reactor/core/scheduler/Schedulers.html)를 사용하거나 직접 생성할 수 있습니다.
 
 ```java
 
-Mono.fromCallable( () -> System.currentTimeMillis() )
-	.repeat()
+Mono.fromCallable(() -> System.currentTimeMillis())
+        .repeat()
     .publishOn(Schedulers.single())
     .log("foo.bar")
     .flatMap(time ->
@@ -181,23 +172,20 @@ Mono.fromCallable( () -> System.currentTimeMillis() )
 
 ## ParallelFlux
 
-[ParallelFlux](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html) can starve your CPU's from any sequence whose work can be subdivided in concurrent
- tasks. Turn back into a `Flux` with `ParallelFlux#sequential()`, an unordered join or
- use arbitrary merge strategies via 'groups()'.
+[ParallelFlux](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/ParallelFlux.html)는 동시에 수행할 수 있는 작업으로 나눌 수 있는 시퀀스에서 CPU를 최대한 활용할 수 있습니다. `ParallelFlux#sequential()`로 다시 `Flux`로 변환하거나, 무순서 조인 또는 `groups()`를 이용한 다양한 병합 전략을 사용할 수 있습니다.
 
 ```java
-Mono.fromCallable( () -> System.currentTimeMillis() )
-	.repeat()
+Mono.fromCallable(() -> System.currentTimeMillis())
+        .repeat()
     .parallel(8) //parallelism
     .runOn(Schedulers.parallel())
-    .doOnNext( d -> System.out.println("I'm on thread "+Thread.currentThread()) )
-    .subscribe()
+    .doOnNext(d -> System.out.println("I'm on thread " + Thread.currentThread()))
+    .subscribe();
 ```
 
+## 사용자 정의 소스: Flux.create와 FluxSink, Mono.create와 MonoSink
 
-## Custom sources : Flux.create and FluxSink, Mono.create and MonoSink
-To bridge a Subscriber or Processor into an outside context that is taking care of
-producing non concurrently, use `Flux#create`, `Mono#create`.
+구독자나 프로세서를 외부 컨텍스트에 연결해야 하고, 그 컨텍스트가 단일 스레드로 데이터를 생성한다면 `Flux#create`, `Mono#create`를 사용하세요.
 
 ```java
 Flux.create(sink -> {
@@ -205,38 +193,38 @@ Flux.create(sink -> {
             sink.next(textField.getText());
          };
 
-         // without cancellation support:
+         // 취소 지원 없이 사용하는 경우
          button.addActionListener(al);
 
-         // with cancellation support:
+         // 취소 지원을 추가하는 경우
          sink.onCancel(() -> {
-         	button.removeListener(al);
+                button.removeListener(al);
          });
     },
-    // Overflow (backpressure) handling, default is BUFFER
+    // 오버플로(백프레셔) 처리, 기본값은 BUFFER
     FluxSink.OverflowStrategy.LATEST)
     .timeout(Duration.ofSeconds(3))
     .doOnComplete(() -> System.out.println("completed!"))
-    .subscribe(System.out::println)
+    .subscribe(System.out::println);
 ```
 
-## The Backpressure Thing
+## 백프레셔란?
 
-Most of this cool stuff uses bounded ring buffer implementation under the hood to mitigate signal processing difference between producers and consumers. Now, the operators and processors or any standard reactive stream component working on the sequence will be instructed to flow in when these buffers have free room AND only then. This means that we make sure we both have a deterministic capacity model (bounded buffer) and we never block (request more data on write capacity). Yup, it's not rocket science after all, the boring part is already being worked by us in collaboration with [Reactive Streams Commons](https://github.com/reactor/reactive-streams-commons) on going research effort.
+이러한 기능 대부분은 프로듀서와 컨슈머 간의 처리 속도 차이를 완화하기 위해 내부적으로 제한된 링 버퍼 구현을 사용합니다. 연산자와 프로세서, 기타 표준 리액티브 스트림 컴포넌트는 버퍼에 여유 공간이 있을 때만 데이터를 흘려보내도록 지시받습니다. 즉, 결정적인 용량 모델(제한된 버퍼)을 유지하면서도 쓰기 용량을 초과해서 데이터를 요청하지 않아 블로킹이 발생하지 않습니다. 지루한 부분은 저희와 [Reactive Streams Commons](https://github.com/reactor/reactive-streams-commons)가 함께 연구하며 처리하고 있으니 걱정하지 마세요.
 
-## What's more in it ?
+## 이 외의 내용
 
-"Operator Fusion" (flow optimizers), health state observers, helpers to build custom reactive components, bounded queue generator, converters from/to Java 9 Flow, Publisher and Java 8 CompletableFuture. The repository contains a `reactor-test` project with test features like the [`StepVerifier`](https://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html).
+"연산자 퓨전"(흐름 최적화), 상태 관찰 도구, 사용자 정의 리액티브 컴포넌트를 만들기 위한 도우미, 제한된 큐 생성기, Java 9 Flow/Publisher와 Java 8 CompletableFuture 간 변환기가 제공됩니다. 저장소에는 [`StepVerifier`](https://projectreactor.io/docs/test/release/api/index.html?reactor/test/StepVerifier.html)와 같은 테스트 기능을 제공하는 `reactor-test` 프로젝트도 포함되어 있습니다.
 
 -------------------------------------
 
-## Reference Guide
+## 레퍼런스 가이드
 https://projectreactor.io/docs/core/release/reference/docs/index.html
 
 ## Javadoc
 https://projectreactor.io/docs/core/release/api/
 
-## Getting started with Flux and Mono
+## Flux와 Mono 시작하기
 https://github.com/reactor/lite-rx-api-hands-on
 
 ## Reactor By Example
@@ -245,9 +233,9 @@ https://www.infoq.com/articles/reactor-by-example
 ## Head-First Spring & Reactor
 https://github.com/reactor/head-first-reactive-with-spring-and-reactor/
 
-## Beyond Reactor Core
-- Everything to jump outside the JVM with the non-blocking drivers from [Reactor Netty](https://github.com/reactor/reactor-netty).
-- [Reactor Addons](https://github.com/reactor/reactor-addons) provide for adapters and extra operators for Reactor 3.
+## Reactor Core 그다음 단계
+- JVM 밖으로 확장할 때는 [Reactor Netty](https://github.com/reactor/reactor-netty)의 논블로킹 드라이버를 활용하세요.
+- [Reactor Addons](https://github.com/reactor/reactor-addons)는 Reactor 3용 어댑터와 추가 연산자를 제공합니다.
 
 -------------------------------------
 _Powered by [Reactive Streams Commons](https://github.com/reactor/reactive-streams-commons)_

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,47 +1,46 @@
-## Usage of JMH tasks
+## JMH 작업 사용 방법
 
-Only execute specific benchmark(s) (wildcards are added before and after):
+특정 벤치마크만 실행합니다(와일드카드는 앞뒤에 자동으로 추가됩니다).
 ```
 ../gradlew jmh --include="(BenchmarkPrimary|OtherBench)"
 ```
-If you want to specify the wildcards yourself, you can pass the full regexp:
+와일드카드를 직접 지정하려면 전체 정규식을 전달하세요.
 ```
 ../gradlew jmh --fullInclude=.*MyBenchmark.*
 ```
 
-Specify extra profilers:
+추가 프로파일러를 지정합니다.
 ```
 ../gradlew jmh --profilers="gc,stack"
 ```
 
-Prominent profilers (for full list call `jmhProfilers` task):
-- comp - JitCompilations, tune your iterations
-- stack - which methods used most time
-- gc - print garbage collection stats
-- hs_thr - thread usage
+주요 프로파일러(전체 목록은 `jmhProfilers` 작업을 실행하세요).
+- comp - JIT 컴파일 횟수, 반복 횟수 조정에 유용
+- stack - 가장 많은 시간을 사용하는 메서드
+- gc - 가비지 컬렉션 통계 출력
+- hs_thr - 스레드 사용량
 
-Change report format from JSON to one of [CSV, JSON, NONE, SCSV, TEXT]:
+리포트 형식을 JSON에서 [CSV, JSON, NONE, SCSV, TEXT] 중 하나로 변경합니다.
 ```
 ./gradlew jmh --format=csv
 ```
 
-Specify JVM arguments:
+JVM 인자를 지정합니다.
 ```
 ../gradlew jmh --jvmArgs="-Dtest.cluster=local"
 ```
 
-Run in verification mode (execute benchmarks with minimum of fork/warmup-/benchmark-iterations):
+검증 모드로 실행합니다(최소한의 fork/워밍업/측정 반복으로 벤치마크 실행).
 ```
 ../gradlew jmh --verify=true
 ```
 
-## Comparing with the baseline
-If you wish you run two sets of benchmarks, one for the current change and another one for the "baseline",
-there is an additional task `jmhBaseline` that will use the latest release:
+## 기준선과 비교하기
+현재 변경분과 "기준선"을 각각 한 번씩 실행하려면 최신 릴리스를 사용하는 `jmhBaseline` 작업을 추가로 실행하세요.
 ```
 ../gradlew jmh jmhBaseline --include=MyBenchmark
 ```
 
-## Resources
-- http://tutorials.jenkov.com/java-performance/jmh.html (Introduction)
-- https://github.com/openjdk/jmh/tree/master/jmh-samples/src/main/java/org/openjdk/jmh/samples (Samples)
+## 참고 자료
+- http://tutorials.jenkov.com/java-performance/jmh.html (입문용)
+- https://github.com/openjdk/jmh/tree/master/jmh-samples/src/main/java/org/openjdk/jmh/samples (샘플)

--- a/docs/modules/ROOT/assets/highlight/README.md
+++ b/docs/modules/ROOT/assets/highlight/README.md
@@ -1,18 +1,12 @@
 # Highlight.js
 
-[![Build Status](https://travis-ci.org/isagalaev/highlight.js.svg?branch=main)]
-(https://travis-ci.org/isagalaev/highlight.js)
+[![Build Status](https://travis-ci.org/isagalaev/highlight.js.svg?branch=main)](https://travis-ci.org/isagalaev/highlight.js)
 
-Highlight.js is a syntax highlighter written in JavaScript. It works in
-the browser as well as on the server. It works with pretty much any
-markup, doesn’t depend on any framework and has automatic language
-detection.
+Highlight.js는 JavaScript로 작성된 문법 하이라이터입니다. 브라우저와 서버 모두에서 동작하며, 거의 모든 마크업과 함께 사용할 수 있고 특정 프레임워크에 의존하지 않으며 자동 언어 감지 기능을 제공합니다.
 
-## Getting Started
+## 시작하기
 
-The bare minimum for using highlight.js on a web page is linking to the
-library along with one of the styles and calling
-[`initHighlightingOnLoad`][1]:
+웹 페이지에서 highlight.js를 사용하기 위한 최소한의 설정은 라이브러리와 스타일 중 하나를 불러오고 [`initHighlightingOnLoad`][1]를 호출하는 것입니다.
 
 ```html
 <link rel="stylesheet" href="/path/to/styles/default.css">
@@ -20,32 +14,25 @@ library along with one of the styles and calling
 <script>hljs.initHighlightingOnLoad();</script>
 ```
 
-This will find and highlight code inside of `<pre><code>` tags; it tries
-to detect the language automatically. If automatic detection doesn’t
-work for you, you can specify the language in the `class` attribute:
+이렇게 하면 `<pre><code>` 태그 안의 코드를 찾아 하이라이트하며, 언어를 자동으로 감지하려 시도합니다. 자동 감지가 잘 동작하지 않는다면 `class` 속성으로 언어를 지정할 수 있습니다.
 
 ```html
 <pre><code class="html">...</code></pre>
 ```
 
-The list of supported language classes is available in the [class
-reference][2].  Classes can also be prefixed with either `language-` or
-`lang-`.
+지원되는 언어 클래스 목록은 [클래스 레퍼런스][2]에서 확인할 수 있습니다. 클래스 이름 앞에 `language-` 또는 `lang-` 접두사를 붙여도 됩니다.
 
-To disable highlighting altogether use the `nohighlight` class:
+하이라이팅을 완전히 비활성화하려면 `nohighlight` 클래스를 사용하세요.
 
 ```html
 <pre><code class="nohighlight">...</code></pre>
 ```
 
-## Custom Initialization
+## 사용자 정의 초기화
 
-When you need a bit more control over the initialization of
-highlight.js, you can use the [`highlightBlock`][3] and [`configure`][4]
-functions. This allows you to control *what* to highlight and *when*.
+highlight.js 초기화를 좀 더 세밀하게 제어하려면 [`highlightBlock`][3]과 [`configure`][4] 함수를 사용하세요. 이를 통해 *무엇을*, *언제* 하이라이트할지 조절할 수 있습니다.
 
-Here’s an equivalent way to calling [`initHighlightingOnLoad`][1] using
-jQuery:
+다음은 jQuery를 사용해 [`initHighlightingOnLoad`][1]와 동일한 동작을 구현한 예시입니다.
 
 ```javascript
 $(document).ready(function() {
@@ -55,9 +42,7 @@ $(document).ready(function() {
 });
 ```
 
-You can use any tags instead of `<pre><code>` to mark up your code. If
-you don't use a container that preserve line breaks you will need to
-configure highlight.js to use the `<br>` tag:
+`<pre><code>` 대신 원하는 태그를 사용해 코드를 마크업할 수도 있습니다. 줄바꿈을 유지하지 않는 컨테이너를 사용한다면 highlight.js가 `<br>` 태그를 사용하도록 설정해야 합니다.
 
 ```javascript
 hljs.configure({useBR: true});
@@ -67,15 +52,13 @@ $('div.code').each(function(i, block) {
 });
 ```
 
-For other options refer to the documentation for [`configure`][4].
+기타 옵션은 [`configure`][4] 문서를 참고하세요.
 
+## 웹 워커
 
-## Web Workers
+매우 큰 코드 조각을 처리할 때 브라우저 창이 멈추지 않도록 웹 워커 안에서 하이라이팅을 실행할 수 있습니다.
 
-You can run highlighting inside a web worker to avoid freezing the browser
-window while dealing with very big chunks of code.
-
-In your main script:
+메인 스크립트 예시는 다음과 같습니다.
 
 ```javascript
 addEventListener('load', function() {
@@ -86,7 +69,7 @@ addEventListener('load', function() {
 })
 ```
 
-In worker.js:
+`worker.js`는 다음과 같습니다.
 
 ```javascript
 onmessage = function(event) {
@@ -96,50 +79,35 @@ onmessage = function(event) {
 }
 ```
 
+## 라이브러리 받기
 
-## Getting the Library
+highlight.js는 호스팅된 브라우저 스크립트 또는 커스텀 빌드 스크립트, 그리고 서버 모듈 형태로 사용할 수 있습니다. 기본 브라우저 스크립트는 AMD와 CommonJS를 모두 지원하므로 빌드 과정 없이도 RequireJS나 Browserify를 사용할 수 있습니다. 서버 모듈 역시 Browserify와 잘 동작하지만, 서버보다는 브라우저에 특화된 빌드 옵션도 선택할 수 있습니다. 자세한 옵션은 [다운로드 페이지][5]를 참고하세요.
 
-You can get highlight.js as a hosted, or custom-build, browser script or
-as a server module. Right out of the box the browser script supports
-both AMD and CommonJS, so if you wish you can use RequireJS or
-Browserify without having to build from source. The server module also
-works perfectly fine with Browserify, but there is the option to use a
-build specific to browsers rather than something meant for a server.
-Head over to the [download page][5] for all the options.
+**GitHub에 직접 링크하지 마세요.** 라이브러리는 소스 상태 그대로 사용할 수 없으며 빌드가 필요합니다. 사전 패키징된 옵션이 맞지 않는다면 [빌드 문서][6]를 참고하세요.
 
-**Don't link to GitHub directly.** The library is not supposed to work straight
-from the source, it requires building. If none of the pre-packaged options
-work for you refer to the [building documentation][6].
-
-**The CDN-hosted package doesn't have all the languages.** Otherwise it'd be
-too big. If you don't see the language you need in the ["Common" section][5],
-it can be added manually:
+**CDN으로 제공되는 패키지에는 모든 언어가 포함되어 있지 않습니다.** 전체를 포함하기엔 용량이 너무 큽니다. ["Common" 섹션][5]에서 원하는 언어를 찾을 수 없다면 수동으로 추가할 수 있습니다.
 
 ```html
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/languages/go.min.js"></script>
 ```
 
-**On Almond.** You need to use the optimizer to give the module a name. For
-example:
+**Almond 사용 시 참고.** 옵티마이저를 사용해 모듈 이름을 지정해야 합니다. 예시는 다음과 같습니다.
 
 ```
 r.js -o name=hljs paths.hljs=/path/to/highlight out=highlight.js
 ```
 
+## 라이선스
 
-## License
+Highlight.js는 BSD 라이선스로 배포됩니다. 자세한 내용은 [LICENSE][7] 파일을 참고하세요.
 
-Highlight.js is released under the BSD License. See [LICENSE][7] file
-for details.
+## 링크
 
-## Links
+공식 사이트: <https://highlightjs.org/>
 
-The official site for the library is at <https://highlightjs.org/>.
+API 및 기타 주제에 대한 자세한 문서는 <https://highlightjs.readthedocs.io/>에서 확인할 수 있습니다.
 
-Further in-depth documentation for the API and other topics is at
-<https://highlightjs.readthedocs.io/>.
-
-Authors and contributors are listed in the [AUTHORS.en.txt][8] file.
+저자와 기여자 목록은 [AUTHORS.en.txt][8] 파일에 정리되어 있습니다.
 
 [1]: https://highlightjs.readthedocs.io/en/latest/api.html#inithighlightingonload
 [2]: https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html

--- a/docs/svg/README.md
+++ b/docs/svg/README.md
@@ -1,81 +1,81 @@
-# Contributing SVGs
+# SVG 기여 가이드
 
-Most images are in SVG format and represent a marble diagram.
-Such SVG are embedded in the javadoc jar, and as such need to be in a `doc-files` folder inside the source hierarchy.
+대부분의 이미지는 SVG 형식이며 마블 다이어그램을 나타냅니다.
+이러한 SVG는 javadoc JAR에 포함되므로 소스 계층 구조 내 `doc-files` 폴더에 위치해야 합니다.
 
-As a result, most SVG live in `/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/`.
+따라서 대부분의 SVG는 `/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/`에 있습니다.
 
-The graphical conventions for SVG marble diagrams are displayed in `/docs/svg/conventions.svg` (in an unoptimized raw SVG).
-One can pick graphical elements from it and add them to a new SVG marble diagram should one want to contribute such a diagram.
+SVG 마블 다이어그램의 그래픽 규칙은 최적화되지 않은 원본 SVG인 `/docs/svg/conventions.svg`에 정리되어 있습니다.
+이 파일에서 그래픽 요소를 가져와 새 SVG 마블 다이어그램에 추가하면 기여에 도움이 됩니다.
 
-Some of these conventions have also been extracted and reworked with a user/reader's perspective in mind, in order to describe how to read a marble diagram.
-These `legend-` SVGs are specific to the reference documentation.
+이 규칙 가운데 일부는 독자 관점에서 마블 다이어그램을 읽는 방법을 설명하도록 추출되어 재가공되었습니다.
+이러한 `legend-` 접두사의 SVG는 레퍼런스 문서에 특화되어 있습니다.
 
-All images that are specific to the reference documentation can be added to the `/docs/asciidoc/images/` folder.
-SVGs purely aimed at the reference guide still need to be optimized, notably the `legend-` ones, otherwise they tend to have rendering issues in the PDF version.
+레퍼런스 문서 전용 이미지는 `/docs/asciidoc/images/` 폴더에 추가할 수 있습니다.
+`legend-` SVG처럼 레퍼런스 가이드를 위한 이미지도 최적화해야 하며, 그렇지 않으면 PDF 버전에서 렌더링 문제가 발생합니다.
 
-## Contributing Marble Diagrams
+## 마블 다이어그램 기여하기
 
-The recommended workflow for editing or contributing new SVG marble diagrams is as follows:
+새 SVG 마블 다이어그램을 편집하거나 기여할 때는 다음 워크플로를 권장합니다.
 
- - Use a standard SVG editor (the cross-platform standalone editor we would recommend is [`Inkscape`](https://inkscape.org))
- - For main labels (eg. for the operator name in a box), use the `Tahoma` font family and fall back to `Nimbus Sans L` for Linux:
+ - 표준 SVG 편집기를 사용하세요(크로스 플랫폼 독립 실행형 편집기로는 [`Inkscape`](https://inkscape.org)를 추천합니다).
+ - 주요 레이블(예: 박스의 연산자 이름)은 `Tahoma` 글꼴 패밀리를 사용하고 Linux에서는 `Nimbus Sans L`로 폴백하세요.
    - `font-family:'Tahoma','Nimbus Sans L'`
- - For labels that should look more like code, use `Lucida Console` font family and fallback to `Courier New`:
+ - 코드처럼 보이게 해야 하는 레이블은 `Lucida Console` 글꼴 패밀리를 사용하고 `Courier New`로 폴백하세요.
    - `font-family:'Lucida Console','Courier New'`
- - Preferably, run the new/edited SVG through an optimizer, but keep it pretty printed (see below)
+ - 가능하다면 새/편집한 SVG를 최적화하되, 아래 안내처럼 보기 좋은 들여쓰기를 유지하세요.
 
-All `*.svg` marble diagrams are found in `/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/` folder.
-This same folder will be embedded in the `-sources.jar` and `-javadoc.jar` artifacts.
+모든 `*.svg` 마블 다이어그램은 `/reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/` 폴더에 있습니다.
+이 폴더는 `-sources.jar`와 `-javadoc.jar` 아티팩트에도 포함됩니다.
 
-Note that there is a `conventions.svg` document that regroups the different graphical conventions for representing recurrent elements of marbles (static operator vs method operator, blocking, timeouts, lambdas, etc...), as well as more SVGs in `/docs/asciidoc/images` (which also includes symlinks to `flux.svg` and `mono.svg` marbles).
+`conventions.svg` 문서는 마블에 반복해서 등장하는 요소(정적 연산자 vs 메서드 연산자, 블로킹, 타임아웃, 람다 등)를 표현하기 위한 그래픽 규칙을 묶어 둡니다. 또한 `/docs/asciidoc/images`에도 더 많은 SVG가 있으며(이 폴더에는 `flux.svg`와 `mono.svg` 마블로 연결되는 심볼릭 링크가 포함됩니다).
 
-### Optimizing the SVG files
+### SVG 파일 최적화하기
 
-We want the SVG size to be kept as small and clutter-free as possible, as the images are embedded in the source and javadoc jars.
-As a result, we recommend that an optimization step be taken when editing/creating SVGs.
+이미지는 소스와 javadoc JAR에 포함되므로 가능한 한 작은 크기를 유지하고 불필요한 내용을 제거해야 합니다.
+따라서 SVG를 편집하거나 새로 만들 때에는 최적화 단계를 거치길 권장합니다.
 
-That said, in order for the SVG source to be readable in editors, we prefer the SVG to be kept pretty printed.
+다만 편집기에서 SVG 소스를 읽기 쉽도록 보기 좋은 들여쓰기를 유지하는 편을 선호합니다.
 
-We also had a lot of problems with arrowheads disappearing during optimizations, which you should keep an eye out for.
+최적화 과정에서 화살표 머리가 사라지는 문제가 자주 발생하므로 주의 깊게 확인하세요.
 
-So the recommended configuration for optimizing is as follows:
+권장 최적화 설정은 다음과 같습니다.
 
- - Use [svgo](https://github.com/svg/svgo) (it is an NPM module, but you can get it on OSX via Homebrew: `brew install svgo`)
- - Only optimize the file(s) you've been editing. For multiple files, prefer exporting the result in a temporary folder for verification first.
- - Use the following command from the repo root to maintain arrowheads and pretty printing while optimizing the SVGs correctly:
- 
+ - [svgo](https://github.com/svg/svgo)를 사용하세요(NPM 모듈이며 macOS에서는 Homebrew로 `brew install svgo`로 설치할 수 있습니다).
+ - 편집한 파일만 최적화하세요. 여러 파일을 다룰 때는 검증을 위해 임시 폴더에 결과를 내보내는 편이 좋습니다.
+ - 리포지터리 루트에서 다음 명령을 실행하면 화살표 머리를 유지하고 보기 좋은 들여쓰기를 유지한 채 SVG를 올바르게 최적화할 수 있습니다.
+
 ```sh
 svgo --input="reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/reduce.svg" --multipass --pretty --indent=1 --precision=2 --disable={cleanupIDs,removeNonInheritableGroupAttrs,removeViewBox,convertShapeToPath}
 ```
 
-TIP: you can use git to stage the file pre-optimization, check it renders correctly post-optimization and revert using `git checkout path/to/file.svg` if that is not the case.
+TIP: 최적화 전 파일을 git으로 스테이징하고, 최적화 후 렌더링이 올바른지 확인한 다음 문제가 있으면 `git checkout path/to/file.svg`로 되돌릴 수 있습니다.
 
-Alternatively, to optimize a whole folder into a temporary folder for comparison, use the `--folder` and `--output` options:
+폴더 전체를 임시 폴더로 최적화하려면 `--folder`와 `--output` 옵션을 사용하세요.
 
 ```sh
 svgo --folder="reactor-core/src/main/java/reactor/core/publisher/doc-files/marbles/" --multipass --pretty --indent=1 --precision=2 --disable={cleanupIDs,removeNonInheritableGroupAttrs,removeViewBox,convertShapeToPath} --output=/tmp/svg/ --quiet
 ```
 
-### Optimization Tips and Tricks
+### 최적화 팁
 
-#### Arrows and other elements disappear
-Try ungrouping the object.
-Some objects are grouped for copy/paste convenience in the `conventions.svg` document, but should be ungrouped.
+#### 화살표나 다른 요소가 사라질 때
+객체의 그룹을 해제해 보세요.
+일부 객체는 `conventions.svg` 문서에서 복사/붙여넣기 편의를 위해 그룹화되어 있지만, 실제 사용 시에는 그룹을 풀어야 합니다.
 
-### Inkscape Tips and Tricks
+### Inkscape 팁
 
-#### On OSX with dual monitor Inkscape 0.x disappear
-Unfortunately, Inkscape with XQuartz is not always ideally working. This disappearing problem is due to misalignment in coordinate systems.
+#### 듀얼 모니터를 사용하는 macOS에서 Inkscape 0.x가 사라지는 문제
+안타깝게도 XQuartz 기반 Inkscape는 항상 완벽하게 작동하지 않습니다. 화면에서 사라지는 문제는 좌표계 정렬이 맞지 않아 발생합니다.
 
-You can deactivate an option in OSX's `Mission Control` preferences: uncheck `Displays have separate spaces`.
-This needs a re-login and has the unfortunate effect that the menu bar will now only appear on the main screen (the one with the dock).
+macOS `Mission Control` 환경설정에서 `디스플레이마다 별도의 Spaces` 옵션을 비활성화하세요.
+이 설정을 변경하면 다시 로그인해야 하며, 메뉴 막대가 이제 도크가 있는 기본 화면에만 표시되는 부작용이 있습니다.
 
-#### Inkscape 0.x is slow as hell to open and close documents
- - Try closing all but one document, then close every tool dialog and restart Inkscape
- - In Preferences, you can try playing with `Rendering` options: number of thread, cache size, display filters quality.
+#### Inkscape 0.x에서 문서를 열거나 닫는 속도가 매우 느릴 때
+ - 문서를 하나만 남기고 모두 닫은 뒤 도구 대화 상자를 닫고 Inkscape를 다시 시작해 보세요.
+ - 환경설정의 `렌더링` 옵션에서 스레드 수, 캐시 크기, 디스플레이 필터 품질을 조정해 보세요.
 
-### How to reduce a rounded rectangle (buffers)
-Double click on the rectangle and select the top left corner (square handle).
-Hold Ctrl (or Cmd) to only move horizontally, and move the handler closer to where you want it.
-Repeat the same operation with the bottom-right handle.
+### 둥근 사각형(버퍼)을 줄이는 방법
+사각형을 두 번 클릭하고 왼쪽 위 모서리(네모 핸들)를 선택하세요.
+가로로만 이동하려면 Ctrl(또는 Cmd) 키를 누른 채 원하는 위치로 핸들을 옮깁니다.
+같은 작업을 오른쪽 아래 핸들에도 반복하세요.


### PR DESCRIPTION
## Summary
- translate the top-level README to Korean while preserving all existing code samples and links
- convert benchmark and documentation SVG contribution READMEs to Korean, keeping formatting and command references intact
- localize the bundled highlight.js README to Korean including configuration and usage notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4811daf24832090d543407b6c5917